### PR TITLE
fix: config base をそのまま使わず、使えるものだけにする

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,19 @@
     "default": {
       "$schema": "https://docs.renovatebot.com/renovate-schema.json",
       "extends": [
-        "config:base",
+        ":dependencyDashboard",
+        ":semanticPrefixFixDepsChoreOthers",
+        ":ignoreModulesAndTests",
+        ":autodetectPinVersions",
+        ":prHourlyLimit2",
+        ":prConcurrentLimit10",
+        "group:recommended",
+        "workarounds:all",
         ":timezone(Asia/Tokyo)"
       ],
       "labels": ["dependencies", "renovate"],
       "schedule": ["after 10pm and before 5am every weekday", "every weekend"],
-      "dependencyDashboard": true,
+      "separateMajorMinor": true,
       "lockFileMaintenance": {
         "enabled": true
       },
@@ -22,16 +29,20 @@
         {
           "groupName": "husky",
           "matchPackagePatterns": ["husky"],
-          "labels": ["renovate", "automerge:false"],
+          "labels": ["dependencies", "renovate", "check needed"],
           "rebaseWhen": "conflicted",
           "automerge": false
         },
-        {
+        { 
+          "groupName": "types",
           "packagePatterns": ["^@types/"],
+          "labels": ["dependencies", "renovate", "check needed"],
           "automerge": false
         },
         {
           "groupName": "jest",
+          "labels": ["dependencies", "renovate", "check needed"],
+          "automerge": false,
           "sourceUrlPrefixes": [
             "https://github.com/facebook/jest",
             "https://github.com/kulshekhar/ts-jest"
@@ -39,6 +50,8 @@
         },
         {
           "groupName": "linters",
+          "labels": ["dependencies", "renovate", "check needed"],
+          "automerge": false,
           "extends": ["packages:linters"],
           "packageNames": ["prettier"],
           "packagePatterns": ["^@typescript-eslint/"]


### PR DESCRIPTION
```json
"default": {
      "$schema": "https://docs.renovatebot.com/renovate-schema.json",
      "extends": [
        ":dependencyDashboard", // 依存関係のダッシュボード作成を許可
        ":semanticPrefixFixDepsChoreOthers", // セマンティクコミットを許可
        ":ignoreModulesAndTests", // node_modules, bower_components, vendor and various test/tests ディレクトリを無視
        ":autodetectPinVersions", // pin , maintain の自動走査
        ":prHourlyLimit2", // PR作成の2時間あたりの作成数
        ":prConcurrentLimit10", // PR作成の最大数
        "workarounds:all",　//  https://docs.renovatebot.com/presets-workarounds の設定
        ":timezone(Asia/Tokyo)"
      ],
      "labels": ["dependencies", "renovate"],
      "schedule": ["after 10pm and before 5am every weekday", "every weekend"],
      "separateMajorMinor": true, // メジャーバージョンは別PR
      "lockFileMaintenance": {
        "enabled": true
      },
      "packageRules": [
        {
          "groupName": "husky",
          "matchPackagePatterns": ["husky"],
          "labels": ["dependencies", "renovate", "check needed"],
          "rebaseWhen": "conflicted",
          "automerge": false
        },
        { 
          "groupName": "types",
          "packagePatterns": ["^@types/"],
          "labels": ["dependencies", "renovate", "check needed"],
          "automerge": false
        },
        {
          "groupName": "jest",
          "labels": ["dependencies", "renovate", "check needed"],
          "automerge": false,
          "sourceUrlPrefixes": [
            "https://github.com/facebook/jest",
            "https://github.com/kulshekhar/ts-jest"
          ]
        },
        {
          "groupName": "linters",
          "labels": ["dependencies", "renovate", "check needed"],
          "automerge": false,
          "extends": ["packages:linters"],
          "packageNames": ["prettier"],
          "packagePatterns": ["^@typescript-eslint/"]
        }
      ]
    }
```